### PR TITLE
Clean up temporary files, prepare for next release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BUILD_DIR=build
 
 NAME=debinate
-VERSION=0.6.0
+VERSION=0.6.1
 
 .PHONY: all clean build package
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-Copyright 2014-2017 Ray Holder
+Copyright 2014-2018 Ray Holder
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](http://img.shields.io/travis/rholder/debinate.svg)](https://travis-ci.org/rholder/debinate) [![Latest Version](http://img.shields.io/badge/latest-0.6.0-brightgreen.svg)](https://github.com/rholder/debinate/releases/tag/v0.6.0) [![License](http://img.shields.io/badge/license-apache%202-brightgreen.svg)](https://github.com/rholder/debinate/blob/master/LICENSE)
+[![Build Status](http://img.shields.io/travis/rholder/debinate.svg)](https://travis-ci.org/rholder/debinate) [![Latest Version](http://img.shields.io/badge/latest-0.6.1-brightgreen.svg)](https://github.com/rholder/debinate/releases/tag/v0.6.1) [![License](http://img.shields.io/badge/license-apache%202-brightgreen.svg)](https://github.com/rholder/debinate/blob/master/LICENSE)
 
 ## What is this?
 Debinate started out as a way to let you roll your very own Python projects with
@@ -16,7 +16,7 @@ applications to ease installation.
 Drop the latest version of `debinate` into your $PATH, set it executable, and
 make sure you own `/opt` if you plan to use the Python `package` command:
 ```bash
-sudo curl -o /usr/local/bin/debinate -L https://github.com/rholder/debinate/releases/download/v0.6.0/debinate && \
+sudo curl -o /usr/local/bin/debinate -L https://github.com/rholder/debinate/releases/download/v0.6.1/debinate && \
 sudo chmod +x /usr/local/bin/debinate && \
 sudo chown $USER:$USER /opt
 ```
@@ -30,7 +30,7 @@ brew install coreutils findutils gnu-tar
 Then drop the latest version of `debinate` into your $PATH, set it executable, and
 make sure you own `/opt` if you plan to use the Python `package` command:
 ```bash
-sudo curl -o /usr/local/bin/debinate -L https://github.com/rholder/debinate/releases/download/v0.6.0/debinate && \
+sudo curl -o /usr/local/bin/debinate -L https://github.com/rholder/debinate/releases/download/v0.6.1/debinate && \
 sudo chmod +x /usr/local/bin/debinate && \
 sudo chown $USER:staff /opt
 ```
@@ -38,7 +38,7 @@ I would consider it experimental because projects with Python dependencies that 
 
 ## Usage
 ```
-Debinate 0.6.0 - roll up your project into a Debian package
+Debinate 0.6.1 - roll up your project into a Debian package
 
 Python:
 

--- a/debian/control
+++ b/debian/control
@@ -1,5 +1,5 @@
 Package: debinate
-Version: 0.6.0
+Version: 0.6.1
 License: Apache 2.0
 Vendor: rholder
 Architecture: all

--- a/debinate
+++ b/debinate
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2014-2017 Ray Holder
+# Copyright 2014-2018 Ray Holder
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 set -o errexit
 set -o pipefail
 
-readonly DEBINATE_VERSION=0.6.0
+readonly DEBINATE_VERSION=0.6.1
 readonly PROVISIONING=.debinate
 readonly DEBINATE_BUILD=${PROVISIONING}/build
 readonly DEBINATE_TARGET=${PROVISIONING}/target
@@ -373,6 +373,21 @@ function build_cli () {
     generate_deb "${deb_root}" "${project_name}" "${project_version}" "${debian_dir}" "${deb_output}"
 }
 
+# clean up ONLY a debinate.tmp-prefixed directory, nothing else
+function safe_cleanup () {
+    local dir_basename=$(basename "$1")
+    case "${dir_basename}" in
+        debinate.tmp*)
+            rm -rf "$1"
+            ;;
+        *)
+            # anything else is considered an error
+            echo "An error occurred while trying to delete $1"
+            exit 1
+            ;;
+    esac
+}
+
 # generate a Debian package archive
 function generate_deb () {
     local deb_root=$1
@@ -381,9 +396,13 @@ function generate_deb () {
     local debian_custom_dir=$4
     local deb_output=$5
 
-    local tmp_dir=$(${MKTEMP} -d)
+    # use $TMPDIR if set, else /tmp, prefix directory with debinate.tmp
+    local tmp_dir=$(${MKTEMP} --tmpdir -d debinate.tmp.XXXXXXXXXX)
     local build_dir="${tmp_dir}/build"
     local target_dir="${tmp_dir}/target"
+
+    # register clean up trap
+    trap "{ safe_cleanup \"${tmp_dir}\"; }" EXIT
 
     # control archive files are staged here
     local debian_dir="${build_dir}/debian"


### PR DESCRIPTION
This provides a safe cleanup mechanism using a `bash` trap that deletes the temporary directory created from running the `debinate build` command. Additionally, a comment has been added to call out that one can override the temporary directory location by setting `TMPDIR`, as documented in the `mktemp` `man` page.

This should resolve the issue described in #21.

Additional changes have been added for publishing the next release.